### PR TITLE
OpenCL fix for Linux Docker

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
 WORKDIR /app
 ARG DEBIAN_FRONTEND=noninteractive
+ARG NV_VER
 RUN apt update
 RUN apt -y install libgl1-mesa-glx libegl1-mesa libxrandr2 libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2 libxi6 libxtst6 curl ffmpeg git nano gnupg2 libsm6 wget unzip libxcb-icccm4 libxkbcommon-x11-0 libxcb-keysyms1 libxcb-icccm4 libxcb-render0 libxcb-render-util0 libxcb-image0
 RUN apt install -y python3 python3-pip
@@ -10,6 +11,8 @@ RUN git clone https://github.com/iperov/DeepFaceLive.git
 
 RUN python -m pip install --upgrade pip
 RUN python -m pip install onnxruntime-gpu==1.12.1 numpy==1.21.6 h5py numexpr protobuf==3.20.1 opencv-python==4.6.0.66 opencv-contrib-python==4.6.0.66 pyqt6==6.3.1 onnx==1.12.0 torch==1.10.0 torchvision==0.11.1
+
+RUN apt install -y libnvidia-compute-$NV_VER
 
 WORKDIR /app/DeepFaceLive
 COPY example.sh example.sh

--- a/build/linux/start.sh
+++ b/build/linux/start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-NV_VER=$(modinfo /usr/lib/modules/$(uname -r)/updates/dkms/nvidia.ko | grep ^version |awk '{print $2}'|awk -F '.' '{print $1}')
+NV_LIB=$(locate nvidia.ko |grep $(uname -r) |grep dkms | head -1)
+NV_VER=$(modinfo $NV_LIB | grep ^version |awk '{print $2}'|awk -F '.' '{print $1}')
 
 DATA_FOLDER=$(pwd)/data/
 declare CAM0 CAM1 CAM2 CAM3

--- a/build/linux/start.sh
+++ b/build/linux/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+NV_VER=$(modinfo /usr/lib/modules/$(uname -r)/updates/dkms/nvidia.ko | grep ^version |awk '{print $2}'|awk -F '.' '{print $1}')
+
 DATA_FOLDER=$(pwd)/data/
 declare CAM0 CAM1 CAM2 CAM3
 printf "\n"
@@ -28,6 +30,6 @@ shift "$(($OPTIND -1))"
 printf "\n"
 
 # Warning xhost + is overly permissive and will reduce system security. Edit as desired
-docker build . -t deepfacelive
+docker build . -t deepfacelive --build-arg NV_VER=$NV_VER
 xhost +
 docker run --ipc host --gpus all -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v $DATA_FOLDER:/data/ $CAM0 $CAM1 $CAM2 $CAM3  --rm -it deepfacelive


### PR DESCRIPTION
- Added libnvidia-compute to the docker environment
- Added variable in start.sh to pull nvidia driver version (ie 515) and pass to Dockerfile

This may not be the best approach but it seems to work well, although it does increase the size of the docker container. I will look into a better way to get OpenCL support into the container.