### PR TITLE
Fix Linux Docker container

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.4.3-cudnn8-devel-ubuntu20.04
 WORKDIR /app
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NV_VER
@@ -11,8 +11,6 @@ RUN git clone https://github.com/iperov/DeepFaceLive.git
 
 RUN python -m pip install --upgrade pip
 RUN python -m pip install onnxruntime-gpu==1.12.1 numpy==1.21.6 h5py numexpr protobuf==3.20.1 opencv-python==4.6.0.66 opencv-contrib-python==4.6.0.66 pyqt6==6.4.0 onnx==1.12.0 torch==1.10.0 torchvision==0.11.1
-
-RUN apt install -y libnvidia-compute-$NV_VER
 
 WORKDIR /app/DeepFaceLive
 COPY example.sh example.sh


### PR DESCRIPTION
Fix issues to recognize NVIDIA drivers, such as `nvidia-smi` and `nvcc --version` inside the container.

I installed locally `nvidia-docker`, with `sudo apt install nvidia-docker2` and updated the Dockerfile base image.
It seems that `apt install -y libnvidia-compute-$NV_VER` was overriding the base image with the working drivers.


This pull request addresses an issue with recognizing NVIDIA drivers inside the container. The problem was solved by installing [nvidia-docker](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) locally with:

```
sudo apt install nvidia-docker2
sudo systemctl restart docker
```

And updating the base image in the Dockerfile. The fix involved removing `apt install -y libnvidia-compute-$NV_VER`, which was overriding the correct driver. As result, `nvidia-smi` and `nvcc --version` now works properly inside the container and of course, Deep Face Live.